### PR TITLE
Added pending deprecation to `prefix` for solid_i18n_patterns.

### DIFF
--- a/example/tests/test_solid_urls.py
+++ b/example/tests/test_solid_urls.py
@@ -1,10 +1,34 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+import sys
 from django.core.urlresolvers import reverse
+from django.conf.urls import url
 from django.utils import translation
 from django.test.utils import override_settings
+from django.views.generic import TemplateView
+from solid_i18n.urls import solid_i18n_patterns
 
 from .base import URLTestCaseBase
+
+
+class PrefixDeprecationTestCase(URLTestCaseBase):
+
+    def setUp(self):
+        super(PrefixDeprecationTestCase, self).setUp()
+        self.test_urls = [
+            url(r'^$', TemplateView.as_view(template_name="test.html"), name='test'),
+            url(r'^$', TemplateView.as_view(template_name="test2.html"), name='test2'),
+        ]
+
+    def test_with_and_without_prefix(self):
+        """
+        Ensure that solid_i18n_patterns works the same with or without a prefix.
+
+        """
+        self.assertEqual(
+            solid_i18n_patterns(*self.test_urls)[0].regex,
+            solid_i18n_patterns('', *self.test_urls)[0].regex,
+        )
 
 
 class TranslationReverseUrlTestCase(URLTestCaseBase):

--- a/example/tests/urls_i18n_copy.py
+++ b/example/tests/urls_i18n_copy.py
@@ -6,7 +6,7 @@ from django.conf.urls import patterns, url, include
 from solid_i18n.urls import solid_i18n_patterns
 from django.views.generic import TemplateView
 
-urlpatterns = solid_i18n_patterns('',
+urlpatterns = solid_i18n_patterns(
     url(r'^$', TemplateView.as_view(template_name="home.html"), name='home'),
     url(r'^about/$', TemplateView.as_view(template_name="about.html"),
         name='about'),

--- a/solid_i18n/urls.py
+++ b/solid_i18n/urls.py
@@ -1,5 +1,7 @@
+import warnings
 from django.conf import settings
 from django.conf.urls import patterns
+from django.utils import six
 from .urlresolvers import SolidLocaleRegexURLResolver
 
 
@@ -12,7 +14,18 @@ def solid_i18n_patterns(prefix, *args):
     Do not adds any language code prefix to default language URL pattern.
     Default language must be set in settings.LANGUAGE_CODE
     """
-    pattern_list = patterns(prefix, *args)
+    if isinstance(prefix, six.string_types):
+        warnings.warn(
+            "Calling solid_i18n_patterns() with the `prefix` argument and with "
+            "tuples instead of django.conf.urls.url() instances is deprecated and "
+            "will no longer work in Django 2.0. Use a list of "
+            "django.conf.urls.url() instances instead.",
+            PendingDeprecationWarning, stacklevel=2
+        )
+        pattern_list = patterns(prefix, *args)
+    else:
+        pattern_list = [prefix] + list(args)
+
     if not settings.USE_I18N:
         return pattern_list
     return [SolidLocaleRegexURLResolver(pattern_list)]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,13 @@
 [tox]
-envlist=py26-14, py27-14, py26-15, py27-15, py32-15, py33-15, py26-16, py27-16, py32-16, py33-16, py27-17, py32-17, py33-17, py34-17
+envlist=
+    py26-14,
+    py27-14,
+    py26-16,
+    py27-16,
+    py33-16,
+    py27-17,
+    py33-17,
+    py34-17
 
 [testenv]
 deps =
@@ -17,24 +25,6 @@ deps =
 basepython = python2.7
 deps =
     django==1.4.15
-    {[testenv]deps}
-
-[testenv:py26-15]
-basepython = python2.6
-deps =
-    django==1.5.10
-    {[testenv]deps}
-
-[testenv:py27-15]
-basepython = python2.7
-deps =
-    django==1.5.10
-    {[testenv]deps}
-
-[testenv:py32-15]
-basepython = python3.2
-deps =
-    django==1.5.10
     {[testenv]deps}
 
 [testenv:py33-15]
@@ -55,22 +45,10 @@ deps =
     django==1.6.7
     {[testenv]deps}
 
-[testenv:py32-16]
-basepython = python3.2
-deps =
-    django==1.6.7
-    {[testenv]deps}
-
 [testenv:py33-16]
 basepython = python3.3
 deps =
     django==1.6.7
-    {[testenv]deps}
-
-[testenv:py32-17]
-basepython = python3.2
-deps =
-    django==1.7
     {[testenv]deps}
 
 [testenv:py33-17]


### PR DESCRIPTION
Fixes #8 

I removed the now unsupported Django version 1.5 as well as Python version 3.2 from the tox.ini. I didn't modify travis.yml however.