### PR TITLE
fix django 1.8 `AppRegistryNotReady("Apps aren't loaded yet.")`

### DIFF
--- a/solid_i18n/middleware.py
+++ b/solid_i18n/middleware.py
@@ -132,4 +132,5 @@ class SolidLocaleMiddleware(LocaleMiddleware):
             for url_pattern in get_resolver(None).url_patterns:
                 if isinstance(url_pattern, SolidLocaleRegexURLResolver):
                     self._is_language_prefix_patterns_used = True
+                    break
         return self._is_language_prefix_patterns_used

--- a/solid_i18n/middleware.py
+++ b/solid_i18n/middleware.py
@@ -27,11 +27,7 @@ class SolidLocaleMiddleware(LocaleMiddleware):
     response_default_language_redirect_class = HttpResponsePermanentRedirect
 
     def __init__(self):
-        self._is_language_prefix_patterns_used = False
-        for url_pattern in get_resolver(None).url_patterns:
-            if isinstance(url_pattern, SolidLocaleRegexURLResolver):
-                self._is_language_prefix_patterns_used = True
-                break
+        self._is_language_prefix_patterns_used = None
 
     @property
     def use_redirects(self):
@@ -131,4 +127,9 @@ class SolidLocaleMiddleware(LocaleMiddleware):
         Returns `True` if the `SolidLocaleRegexURLResolver` is used
         at root level of the urlpatterns, else it returns `False`.
         """
+        if self._is_language_prefix_patterns_used is None:
+            self._is_language_prefix_patterns_used = False
+            for url_pattern in get_resolver(None).url_patterns:
+                if isinstance(url_pattern, SolidLocaleRegexURLResolver):
+                    self._is_language_prefix_patterns_used = True
         return self._is_language_prefix_patterns_used


### PR DESCRIPTION
when using uwsgi under django 1.8 current middleware causes error:

```
  File ".../venv/local/lib/python2.7/site-packages/solid_i18n/middleware.py", line 31, in __init__
    for url_pattern in get_resolver(None).url_patterns:
  File ".../venv/local/lib/python2.7/site-packages/django/core/urlresolvers.py", line 401, in url_patterns
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
  File ".../venv/local/lib/python2.7/site-packages/django/core/urlresolvers.py", line 395, in urlconf_module
    self._urlconf_module = import_module(self.urlconf_name)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "./multitest/urls.py", line 16, in <module>
    admin.autodiscover()
  File ".../venv/local/lib/python2.7/site-packages/django/contrib/admin/__init__.py", line 24, in autodiscover
    autodiscover_modules('admin', register_to=site)
  File ".../venv/local/lib/python2.7/site-packages/django/utils/module_loading.py", line 67, in autodiscover_modules
    for app_config in apps.get_app_configs():
  File ".../venv/local/lib/python2.7/site-packages/django/apps/registry.py", line 137, in get_app_configs
    self.check_apps_ready()
  File ".../venv/local/lib/python2.7/site-packages/django/apps/registry.py", line 124, in check_apps_ready
    raise AppRegistryNotReady("Apps aren't loaded yet.")
```

this pull request resolves this problem