### PR TITLE
feature: Add support for django1.6 legacy projects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-django>=1.8,<1.10
+django>=1.6,<1.10
+requests==2.11.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,1 +1,2 @@
 pytest-django==2.8.0
+django-nose==1.4.3

--- a/solid_i18n/contrib.py
+++ b/solid_i18n/contrib.py
@@ -2,7 +2,7 @@
 Contains some code, copied from django, to support different versions of django.
 """
 from django.utils.encoding import iri_to_uri
-from django.utils.encoding import escape_uri_path
+from requests.utils import quote
 
 
 def get_full_path(request, force_append_slash=False):
@@ -13,7 +13,7 @@ def get_full_path(request, force_append_slash=False):
     # RFC 3986 requires query string arguments to be in the ASCII range.
     # Rather than crash if this doesn't happen, we encode defensively.
     return '%s%s%s' % (
-        escape_uri_path(request.path),
+        quote(request.path),
         '/' if force_append_slash and not request.path.endswith('/') else '',
         ('?' + iri_to_uri(request.META.get('QUERY_STRING', ''))) if request.META.get('QUERY_STRING', '') else ''
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{27,34,35}-django{18,19},
+    py{27,34,35}-django{16,17,18,19},
 
 [testenv]
 basepython =
@@ -8,6 +8,8 @@ basepython =
     py34: python3.4
     py35: python3.5
 deps =
+    django16: Django>=1.6,<1.7
+    django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     py27-django19: coverage


### PR DESCRIPTION
Switch django escape_uri_path function (unavailable in django 1.6) with requests quote

tested on my legacy project